### PR TITLE
Add simple multi-agent demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # openaidemo
-Demo code to use openai
+
+This demo shows a simple multi-agent system with a small web UI. It uses a
+message bus implementing a basic MCP/Agent2Agent style protocol so agents can
+communicate. Three agents are included:
+
+- **WeatherAgent** – returns mock weather data
+- **TravelAgent** – suggests sights to see
+- **NewsAgent** – provides short news headlines
+
+The UI displays their responses side by side. The default city is Beijing but
+any city present in the mock data may be specified using the `city` query
+parameter.
+
+## Running
+
+1. Install Flask:
+   ```bash
+   pip install Flask
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:5000/` in your browser and optionally change the
+   city using the input box.

--- a/agents.py
+++ b/agents.py
@@ -1,0 +1,92 @@
+class MCPMessage:
+    def __init__(self, sender, recipient, content, msg_type="query"):
+        self.sender = sender
+        self.recipient = recipient
+        self.content = content
+        self.msg_type = msg_type
+
+
+class MCPBus:
+    """Simple message bus implementing an MCP-like protocol."""
+
+    def __init__(self):
+        self.agents = {}
+
+    def register(self, agent):
+        self.agents[agent.name] = agent
+
+    def send(self, message: MCPMessage):
+        recipient = self.agents.get(message.recipient)
+        if not recipient:
+            raise ValueError(f"No recipient {message.recipient}")
+        return recipient.handle(message)
+
+
+class Agent:
+    def __init__(self, name, bus: MCPBus):
+        self.name = name
+        self.bus = bus
+        bus.register(self)
+
+    def handle(self, message: MCPMessage):
+        raise NotImplementedError
+
+
+class WeatherAgent(Agent):
+    def __init__(self, bus: MCPBus):
+        super().__init__("WeatherAgent", bus)
+        self.weather_data = {
+            "Beijing": "Sunny, 25\u00b0C",
+            "Paris": "Cloudy, 18\u00b0C",
+            "New York": "Rainy, 10\u00b0C",
+        }
+
+    def handle(self, message: MCPMessage):
+        city = message.content.get("city", "Beijing")
+        return self.weather_data.get(city, "Weather data not available.")
+
+
+class TravelSuggestionAgent(Agent):
+    def __init__(self, bus: MCPBus):
+        super().__init__("TravelAgent", bus)
+        self.suggestions = {
+            "Beijing": [
+                "Visit the Great Wall",
+                "Explore the Forbidden City",
+            ],
+            "Paris": [
+                "See the Eiffel Tower",
+                "Walk along the Seine",
+            ],
+            "New York": [
+                "Check out Times Square",
+                "Visit Central Park",
+            ],
+        }
+
+    def handle(self, message: MCPMessage):
+        city = message.content.get("city", "Beijing")
+        return self.suggestions.get(city, ["No suggestions available."])
+
+
+class NewsAgent(Agent):
+    def __init__(self, bus: MCPBus):
+        super().__init__("NewsAgent", bus)
+        self.news = {
+            "Beijing": [
+                "Beijing hosts international cultural festival",
+                "New museum opens in downtown Beijing",
+            ],
+            "Paris": [
+                "Paris Fashion Week kicks off",
+                "Local bakery wins national award",
+            ],
+            "New York": [
+                "Marathon brings thousands to NYC",
+                "New art exhibition opens at MoMA",
+            ],
+        }
+
+    def handle(self, message: MCPMessage):
+        city = message.content.get("city", "Beijing")
+        return self.news.get(city, ["No news available."])

--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+from flask import Flask, render_template, request
+
+from agents import MCPBus, MCPMessage, WeatherAgent, TravelSuggestionAgent, NewsAgent
+
+app = Flask(__name__)
+
+# Initialize message bus and agents
+bus = MCPBus()
+weather_agent = WeatherAgent(bus)
+travel_agent = TravelSuggestionAgent(bus)
+news_agent = NewsAgent(bus)
+
+
+@app.route("/")
+def index():
+    city = request.args.get("city", "Beijing")
+
+    # Query each agent using the Agent2Agent protocol via the message bus
+    weather = bus.send(MCPMessage("web", "WeatherAgent", {"city": city}))
+    suggestions = bus.send(MCPMessage("web", "TravelAgent", {"city": city}))
+    news = bus.send(MCPMessage("web", "NewsAgent", {"city": city}))
+
+    return render_template(
+        "index.html",
+        city=city,
+        weather=weather,
+        suggestions=suggestions,
+        news=news,
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Multi-Agent Demo</title>
+    <style>
+        .container {
+            display: flex;
+            justify-content: space-between;
+        }
+        .panel {
+            flex: 1;
+            padding: 10px;
+        }
+    </style>
+</head>
+<body>
+    <form method="get">
+        City: <input name="city" value="{{ city }}">
+        <input type="submit" value="Update">
+    </form>
+    <div class="container">
+        <div class="panel" id="weather">
+            <h2>Weather</h2>
+            <p>{{ weather }}</p>
+        </div>
+        <div class="panel" id="travel">
+            <h2>Travel Suggestions</h2>
+            <ul>
+                {% for suggestion in suggestions %}
+                <li>{{ suggestion }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+        <div class="panel" id="news">
+            <h2>News</h2>
+            <ul>
+                {% for item in news %}
+                <li>{{ item }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add WeatherAgent, TravelAgent and NewsAgent using an MCP-style message bus
- provide Flask web UI to query agents and display results
- document how to run the demo

## Testing
- `python -m py_compile agents.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6843a4eb16f88324a41e62ed661c0964